### PR TITLE
No index check on writing to phase_o in testphase

### DIFF
--- a/msrc/hyposat_phase.f
+++ b/msrc/hyposat_phase.f
@@ -370,7 +370,8 @@ c
       subroutine testphase (phid0,icha,dis)
       real*8 dis
       integer icha
-      character phid*8,phid0*8,s*1, phidd*8, phase_o(20)*8
+      PARAMETER MAX_ICHA=50
+      character phid*8,phid0*8,s*1, phidd*8, phase_o(MAX_ICHA)*8
       logical flags
 
       save phase_o
@@ -776,7 +777,7 @@ c
       else
          phid0 = phid
       endif
-
+      if (icha.ge.MAX_ICHA) goto 50
       do 150 j=1,icha
       if(phase_o(icha).eq.phid) go to 50
 150   continue


### PR DESCRIPTION
Experienced a crash where Hyposat tried to write to positon 21 in phase_o which was allocated with size 20.

There was no check on icha > 20.

Extended size to 50 and added check 